### PR TITLE
Fix bug in .smi file ID handling on SMILES parse error

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ INSTALLATION
 ==========================================================================================
 
 Follow these steps on Linux/OSX:
- 
+
 1. ```Download and install Anaconda2 for Python 2.7 from https://www.continuum.io/downloads```
-2. Open terminal in Mac/Linux and run ```conda install -c https://conda.anaconda.org/rdkit rdkit``` 
+2. Open terminal in Mac/Linux and run ```conda install -c https://conda.anaconda.org/rdkit rdkit```
 3. Now run: ```conda install scikit-learn=0.17``` (PIDGINv2 uses Scikit-learn v17)
 4. Navigate the directory you wish to install PIDGINv2 and in Mac/Linux terminal run ```git clone https://github.com/lhm30/PIDGINv2/``` (recommended) or download/extract the zip from GitHub webpage
 5. Download and unzip models.zip into the PIDGINv2 directory from here: ```http://tinyurl.com/zhv3m5n``` (leave .pkl.zip files compressed)
-6. If you would like decision tree capabilities, open terminal in Mac/Linux and run ```conda install pydot graphviz``` 
+6. If you would like decision tree capabilities, open terminal in Mac/Linux and run ```conda install pydot graphviz```
 
 * N.B Step 5 may take up to 10 minutes
 
@@ -50,54 +50,58 @@ IMPORTANT
 ==========================================================================================
 
 *	You MUST download the models before running!
-*	The program recognises line-separated SMILES in .csv format
+*	The program recognises as input line-separated SMILES in either .csv or .smi format (if the input file contains data additional to the SMILES string, the first entries are interpreted as identifiers – see http://opensmiles.org/opensmiles.html §4.5)
 *	Molecules Should be standardized before running models
 *	ChemAxon Standardizer should be used for structure canonicalization and is free for academic use at (http://www.chemaxon.com)
 *	Protocol used to standardise these molecules is provided: StandMoleProt.xml
-*	Do not modify the 'models', 'bg_predictions.txt' etc. names or directories 
+*	Do not modify the 'models', 'bg_predictions.txt' etc. names or directories
 *	cytotox_library.csv and nontoxic_background.csv are included for use as example dataset for testing
 
 INSTRUCTIONS
 ==========================================================================================
 
-1. ```predict_raw.py filename.csv N_cores```
+1. ```predict_raw.py filename.csv N_cores organism```
     This script outputs the Platt-scaled (sigmoid) probabilities of the Random Forest classifier for the compounds in a matrix.
-    
+
+    If using "Organism" it must be as specified in the classes_in_model.txt and enclosed by quotes ("").
+
     Example of how to run the code:
 
     ```
     python predict_raw.py input.csv 4
     ```
-	
+
 	Output is a matrix of Platt-scaled probabilities for an input list of compounds calculated on a machine using 4 cores
 
 
-2. ```predict_binary.py filename.csv N_cores tpr_threshold```
+2. ```predict_binary.py filename.csv N_cores tpr_threshold organism```
     This script generates binary predictions for the models after application of a user-specified predicted true-positive rate (TPR) threshold.
-    
-    The choice of required TPR applies a given confidence when binarizing predictions (i.e. an acceptable True Positive (TP) rate)
-   
+
+    The choice of required TPR applies a given confidence when binarizing predictions (i.e. an acceptable True Positive (TP) rate).
+
+    If using "Organism" it must be as specified in the classes_in_model.txt and enclosed by quotes ("").
+
     Example of how to run the code:
-    
+
     ```
     python predict_binary.py input.csv 30 0.5
     ```
-    
+
     where 30 cores are used to produce predictions, and 0.5 would apply a 50% TPR confidence threshold
-  
-    
+
+
 3. ```predict_enriched.py filename.csv N_cores tpr_threshold DisGeNET_threshold organism```
-    This script enriched targets, NCBI Biosystems pathways and DisGeNET diseases for a library of compounds, when compared to a precomputed target predictions from a background set of 2,000,000 compounds from PubChem (bg_predictions.txt). 
+    This script enriched targets, NCBI Biosystems pathways and DisGeNET diseases for a library of compounds, when compared to a precomputed target predictions from a background set of 2,000,000 compounds from PubChem (bg_predictions.txt).
 
     The protocol corrects for promiscuous models / biases in training data and to which targets are statistically associated with compounds in filename.csv.
-    
+
     Target predictions for filename.csv are compared against PubChem predictions using the Prediction Ratio (ref. http://tinyurl.com/predratio), Odd's Ratio and Fishers Test p-values.
-    
+
     For tables with large numbers, the (inexact) chi-square test implemented in the function chi2 test should be used. Pathways and DisGeNET predictions are compared against PubChem predictions using the Prediction Ratio, Odd's Ratio and Chi-square test of independence p-values.
 
     bg_predictions.txt contains rows of target models with corresponding columns for the number of background compounds from PubChem at a given TPR threshold (to 2DP).
-    
-    DisGeNET_diseases.txt contains disease data used to annotate target predictions. DisGeNET gene-disease score takes into account the number and type of sources (level of curation, organisms), and the number of publications supporting the association. The score ranges from 0 to 1 to give confidence for annotations. A DisGeNET_threshold can be supplied at runtime when annotating predictions with diseases (0.06 threshold applied by default, which includes associations from curated sources/animal models supporting them or reported in 20-200 papers). More info on the score here: http://disgenet.org/web/DisGeNET/menu/dbinfo#score 
+
+    DisGeNET_diseases.txt contains disease data used to annotate target predictions. DisGeNET gene-disease score takes into account the number and type of sources (level of curation, organisms), and the number of publications supporting the association. The score ranges from 0 to 1 to give confidence for annotations. A DisGeNET_threshold can be supplied at runtime when annotating predictions with diseases (0.06 threshold applied by default, which includes associations from curated sources/animal models supporting them or reported in 20-200 papers). More info on the score here: http://disgenet.org/web/DisGeNET/menu/dbinfo#score
 
 	If using "Organism" it must be as specified in the classes_in_model.txt and enclosed by quotes ("")
 
@@ -106,73 +110,73 @@ INSTRUCTIONS
     ```
     python predict_enriched.py input.csv 4 0.5 0.06 "Homo sapiens (Human)"
     ```
-    
+
     The output is a ranked list of targets that are more statistically associated with the input compounds. A low Prediction Ratio, Odd's Ratio and p-value metric indicates a higher enrichment for a target/pathway/disease when compared to the background rate
-    
-    
+
+
 4. ```predict_enriched_two_libraries.py input_active_library.csv input_inactive_library.csv tpr_threshold DisGeNET_threshold organism```
     This script calculates enriched targets, NCBI BioSystems pathways and DisGeNET for two compound libraries (e.g could be phenotypically active compounds and to phenotypically inactive compounds).
 
     The protocol corrects for promiscuous models / biases in training data and to which targets are statistically associated with compounds in input_active_library.csv.
-    
+
     Target predictions for input_active_library.csv are compared against input_inactive_library.csv predictions using the Prediction Ratio (ref. http://tinyurl.com/predratio), Odd's Ratio and Fishers Test p-values.
-    
+
     For tables with large numbers, the (inexact) chi-square test implemented in the function chi2 test should be used. Pathways and DisGeNET predictions are compared against PubChem predictions using the Prediction Ratio, Odd's Ratio and Chi-square test of independence p-values.
 
 	Organism must be as specified in the classes_in_model.txt and enclosed by quotes ("")
-	
+
     Example of how to run the code:
-	
+
     ```
     python predict_enriched_two_libraries.py filename_1.csv filename_2.csv 10 0.9 0.3 "Homo sapiens (Human)"
     ```
-    
+
     The output is a ranked list of targets that are more statistically associated with the input compounds. A low Prediction Ratio, Odd's Ratio and p-value metric indicates a higher enrichment for a target/pathway/disease when compared to the inactive compound set.
-    
-    
+
+
 5. ```predict_per_comp.py filename_1.csv N_cores tpr_threshold DisGeNET_threshold organism```
     This script calculates target, pathway and disease hits per compound and represents them in a matrix. The DisGeNET threshold and organism are optional. Organism must be as specified in the classes_in_model.txt and enclosed by quotes ("")
-    
+
     Example of how to run the code:
-	
+
     ```
     python predict_per_comp.py input.csv 30 0.5 0.3 "Homo sapiens (Human)"
     ```
-    
-    
+
+
 6. ```predict_target_fingerprints.py filename_1.csv N_cores tpr_threshold organism```
     This script calculates target probabilities per compound in a transposed (columns are targets), simplified a matrix. These can be used as a fingerprint/descriptor for biological space. Organism filter is optional. If filtering predictions by organism, this must be as specified in the classes_in_model.txt and enclosed by quotes ("")
-    
+
     Example of how to run the code:
-	
+
     ```
     python predict_target_fingerprints.py input.csv 30 0.5 "Homo sapiens (Human)"
     ```
-    
-    
+
+
 7. ```predict_enriched_two_libraries_decision_tree.py filename_1.csv filename_2.csv N_cores tpr_threshold DisGeNET_threshold minimum_sample_split minimum_leaf_split max_depth organism```
     This script calculates target, pathway and disease hits enrichment and visualises the target predictions in a decision tree (jpg file). The DisGeNET threshold and organism are optional. As always, organism must be enclosed by quotes ("")
-    
+
     Example of how to run the code:
-	
+
     ```
     python predict_enriched_two_libraries_decision_tree.py cytotox_library.csv nontoxic_background.csv 10 0.5 0.5 2 2 5 "Homo sapiens (Human)"
     ```
-    
-   
+
+
 8. ```predict_enriched_decision_tree.py filename_1.csv N_cores tpr_threshold DisGeNET_threshold minimum_sample_split minimum_leaf_split max_depth N_kmeans_clusters organism```
     This script calculates target, pathway and disease hits enrichment and visualises the target predictions in a decision tree (jpg file). This code uses kmeans clustering to cluster predictions within the input dataset, as a method to split input data into hypothetical modes-of-action. The number of clusters is therefore subjective and unsupervised. The DisGeNET threshold and organism are optional. As always, organism must be enclosed by quotes ("")
-    
+
     Example of how to run the code:
-	
+
     ```
     python predict_enriched_decision_tree.py cytotox_library.csv 10 0.5 0.5 2 2 5 5 "Homo sapiens (Human)"
     ```
-    
+
 9. ```sim_to_train.py filename.csv N_cores```
     This script conducts Tanimoto coefficient (Tc) similarity analysis for input compounds in filename.csv and the training data in PIDGIN. This can be used to support prediction interpretation to indicate which compounds are driving predictions. Two files are produced; The first is a matrix similar to the predict_raw script above, which has a similarity matrix of compounds vs. target instead of the raw predictions. The second is a detailed breakdown of the nearest neighbour compounds in the training set (i.e. their affinity, confidence and which organism this is extracted from - since ortholog bioactivity data is also used).    
     Example of how to run the code:
-	
+
     ```
     python sim_to_train.py cytotox_library.csv 10
     ```

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ IMPORTANT
 ==========================================================================================
 
 *	You MUST download the models before running!
-*	The program recognises as input line-separated SMILES in either .csv or .smi format (if the input file contains data additional to the SMILES string, the first entries are interpreted as identifiers – see the [OpenSMILES specification](http://opensmiles.org/opensmiles.html) §4.5)
+*	The program recognises as input line-separated SMILES in either .csv or .smi format (if the input file contains data additional to the SMILES string, the first entries after the SMILES are interpreted as identifiers – see the [OpenSMILES specification](http://opensmiles.org/opensmiles.html) §4.5)
 *	Molecules Should be standardized before running models
 *	ChemAxon Standardizer should be used for structure canonicalization and is free for academic use at (http://www.chemaxon.com)
 *	Protocol used to standardise these molecules is provided: StandMoleProt.xml

--- a/README.md
+++ b/README.md
@@ -145,7 +145,11 @@ INSTRUCTIONS
 
 
 6. ```predict_target_fingerprints.py filename_1.csv N_cores tpr_threshold organism```
-    This script calculates target probabilities per compound in a transposed (columns are targets), simplified a matrix. These can be used as a fingerprint/descriptor for biological space. Organism filter is optional. If filtering predictions by organism, this must be as specified in the classes_in_model.txt and enclosed by quotes ("")
+    This script calculates target probabilities per compound in a transposed (columns are targets), simplified a matrix. These can be used as a fingerprint/descriptor for biological space.
+
+    tp_threshold may be set to "None" to generate raw descriptors rather than fingerprints.
+
+    Organism filter is optional. If filtering predictions by organism, this must be as specified in the classes_in_model.txt and enclosed by quotes ("")
 
     Example of how to run the code:
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ IMPORTANT
 ==========================================================================================
 
 *	You MUST download the models before running!
-*	The program recognises as input line-separated SMILES in either .csv or .smi format (if the input file contains data additional to the SMILES string, the first entries are interpreted as identifiers – see http://opensmiles.org/opensmiles.html §4.5)
+*	The program recognises as input line-separated SMILES in either .csv or .smi format (if the input file contains data additional to the SMILES string, the first entries are interpreted as identifiers – see the [OpenSMILES specification](http://opensmiles.org/opensmiles.html) §4.5)
 *	Molecules Should be standardized before running models
 *	ChemAxon Standardizer should be used for structure canonicalization and is free for academic use at (http://www.chemaxon.com)
 *	Protocol used to standardise these molecules is provided: StandMoleProt.xml

--- a/predict_binary.py
+++ b/predict_binary.py
@@ -25,13 +25,13 @@ def introMessage():
 	print '==============================================================================================\n'
 	return
 
-	
+
 #calculate 2048bit morgan fingerprints, radius 2
 def calcFingerprints(smiles):
 	m1 = Chem.MolFromSmiles(smiles)
 	fp = AllChem.GetMorganFingerprintAsBitVect(m1,2, nBits=2048)
 	binary = fp.ToBitString()
-	return list(binary) 
+	return list(binary)
 
 #calculate fingerprints for chunked array of smiles
 def arrayFP(inp):
@@ -67,8 +67,15 @@ def importQuery(in_file):
 		processed_smi += result[1]
 	pool.close()
 	pool.join()
-	#if IDs aren't present, use SMILES as IDs
-	if not ids:
+	#remove IDs of SMILES parsing errors
+	if ids:
+		processed_ids = []
+		for idx, smi in enumerate(query):
+			if smi in processed_smi:
+				processed_ids.append(ids[idx])
+		ids = processed_ids
+	#if IDs weren't present, use SMILES as IDs
+	else:
 		ids = processed_smi
 	return matrix[:current_end], processed_smi, ids
 
@@ -89,7 +96,7 @@ def open_Model(mod):
 			clf = cPickle.load(fid)
 	return clf
 
-#prediction worker	
+#prediction worker
 def doTargetPrediction(pickled_model_name):
 	if os.name == 'nt': sep = '\\'
 	else: sep = '/'

--- a/predict_binary_similarity_two_libraries.py
+++ b/predict_binary_similarity_two_libraries.py
@@ -69,8 +69,15 @@ def importQuery(in_file):
 		processed_smi += result[1]
 	pool.close()
 	pool.join()
-	#if IDs aren't present, use SMILES as IDs
-	if not ids:
+	#remove IDs of SMILES parsing errors
+	if ids:
+		processed_ids = []
+		for idx, smi in enumerate(query):
+			if smi in processed_smi:
+				processed_ids.append(ids[idx])
+		ids = processed_ids
+	#if IDs weren't present, use SMILES as IDs
+	else:
 		ids = processed_smi
 	return matrix[:current_end], processed_smi, ids
 

--- a/predict_enriched.py
+++ b/predict_enriched.py
@@ -30,13 +30,13 @@ def introMessage():
 	print ' Address: Centre For Molecular Informatics, Dept. Chemistry, Lensfield Road, Cambridge CB2 1EW'
 	print '==============================================================================================\n'
 	return
-	
+
 #calculate 2048bit morgan fingerprints, radius 2
 def calcFingerprints(smiles):
 	m1 = Chem.MolFromSmiles(smiles)
 	fp = AllChem.GetMorganFingerprintAsBitVect(m1,2, nBits=2048)
 	binary = fp.ToBitString()
-	return list(binary) 
+	return list(binary)
 
 #calculate fingerprints for chunked array of smiles
 def arrayFP(inp):
@@ -47,11 +47,11 @@ def arrayFP(inp):
 		except:
 			print 'SMILES Parse Error: ' + i
 	return outfp
-	
+
 #import user query
 def importQuery(in_file):
 	query = open(in_file).read().splitlines()
-	#collect IDs, if present
+	#discard IDs, if present
 	if len(query[0].split()) > 1:
 		query = [line.split()[0] for line in query]
 	matrix = np.empty((len(query), 2048), dtype=np.uint8)
@@ -90,8 +90,8 @@ def getDisgenetInfo():
 		try:
 			return_dict2[(l[1],l[0])] = float(l[2])
 		except ValueError: pass
-	return return_dict1, return_dict2 
-	
+	return return_dict1, return_dict2
+
 #get info for biosystems pathways
 def getPathwayInfo():
 	if os.name == 'nt': sep = '\\'
@@ -105,7 +105,7 @@ def getPathwayInfo():
 		except KeyError:
 			return_dict1[l[0]] = [l[1]]
 		return_dict2[l[1]] = l[2:]
-	return return_dict1, return_dict2 
+	return return_dict1, return_dict2
 
 #get pre-calculated bg hits from PubChem
 def getBGhits(threshold):
@@ -122,7 +122,7 @@ def calcPredictionRatio(preds1,preds2):
 	preds1_percentage = float(preds1)/float(len(querymatrix1))
 	preds2_percentage = float(preds2)/float(2000000)
 	if preds1 == 0 and preds2 == 0: return None
-	if preds1 == 0: return 999.0, round(preds1_percentage,3), round(preds2_percentage,3) 
+	if preds1 == 0: return 999.0, round(preds1_percentage,3), round(preds2_percentage,3)
 	if preds2 == 0: return 0.0, round(preds1_percentage,3), round(preds2_percentage,3)
 	return round(preds2_percentage/preds1_percentage,3), round(preds1_percentage,3), round(preds2_percentage,3)
 
@@ -158,7 +158,7 @@ def performTargetPrediction(models):
 		percent = (float(i)/float(len(models)))*100 + 1
 		sys.stdout.write(' Performing Classification on Query Molecules: %3d%%\r' % percent)
 		sys.stdout.flush()
-		if result is not None: 
+		if result is not None:
 			prediction_results.append(result)
 			updateHits(disease_links,disease_hits,result[1],result[2],result[4])
 			updateHits(pathway_links,pathway_hits,result[1],result[2],result[4])
@@ -166,7 +166,7 @@ def performTargetPrediction(models):
 	pool.join()
 	return prediction_results
 
-#update counts for each pathway/disease that is hit by predictions	
+#update counts for each pathway/disease that is hit by predictions
 def updateHits(links,hits,uniprot,hit1,hit2):
 	try:
 		for idx in links[uniprot]:

--- a/predict_enriched.py
+++ b/predict_enriched.py
@@ -51,6 +51,9 @@ def arrayFP(inp):
 #import user query
 def importQuery(in_file):
 	query = open(in_file).read().splitlines()
+	#collect IDs, if present
+	if len(query[0].split()) > 1:
+		query = [line.split()[0] for line in query]
 	matrix = np.empty((len(query), 2048), dtype=np.uint8)
 	smiles_per_core = int(math.ceil(len(query) / N_cores)+1)
 	chunked_smiles = [query[x:x+smiles_per_core] for x in xrange(0, len(query), smiles_per_core)]

--- a/predict_enriched_decision_tree.py
+++ b/predict_enriched_decision_tree.py
@@ -52,7 +52,7 @@ def arrayFP(inp):
 #import user query
 def importQuery(in_file):
 	query = open(in_file).read().splitlines()
-	#collect IDs, if present
+	#discard IDs, if present
 	if len(query[0].split()) > 1:
 		query = [line.split()[0] for line in query]
 	matrix = np.empty((len(query), 2048), dtype=np.uint8)

--- a/predict_enriched_two_libraries.py
+++ b/predict_enriched_two_libraries.py
@@ -27,13 +27,13 @@ def introMessage():
 	print ' Address: Centre For Molecular Informatics, Dept. Chemistry, Lensfield Road, Cambridge CB2 1EW'
 	print '==============================================================================================\n'
 	return
-	
+
 #calculate 2048bit morgan fingerprints, radius 2
 def calcFingerprints(smiles):
 	m1 = Chem.MolFromSmiles(smiles)
 	fp = AllChem.GetMorganFingerprintAsBitVect(m1,2, nBits=2048)
 	binary = fp.ToBitString()
-	return list(binary) 
+	return list(binary)
 
 #calculate fingerprints for chunked array of smiles
 def arrayFP(inp):
@@ -44,11 +44,11 @@ def arrayFP(inp):
 		except:
 			print 'SMILES Parse Error: ' + i
 	return outfp
-	
+
 #import user query
 def importQuery(in_file):
 	query = open(in_file).read().splitlines()
-	#collect IDs, if present
+	#discard IDs, if present
 	if len(query[0].split()) > 1:
 		query = [line.split()[0] for line in query]
 	matrix = np.empty((len(query), 2048), dtype=np.uint8)
@@ -87,8 +87,8 @@ def getDisgenetInfo():
 		try:
 			return_dict2[(l[1],l[0])] = float(l[2])
 		except ValueError: pass
-	return return_dict1, return_dict2 
-	
+	return return_dict1, return_dict2
+
 #get info for biosystems pathways
 def getPathwayInfo():
 	if os.name == 'nt': sep = '\\'
@@ -102,14 +102,14 @@ def getPathwayInfo():
 		except KeyError:
 			return_dict1[l[0]] = [l[1]]
 		return_dict2[l[1]] = l[2:]
-	return return_dict1, return_dict2 
+	return return_dict1, return_dict2
 
 #calculate prediction ratio for two sets of predictions
 def calcPredictionRatio(preds1,preds2):
 	preds1_percentage = float(preds1)/float(len(querymatrix1))
 	preds2_percentage = float(preds2)/float(len(querymatrix2))
 	if preds1 == 0 and preds2 == 0: return None
-	if preds1 == 0: return 999.0, round(preds1_percentage,3), round(preds2_percentage,3) 
+	if preds1 == 0: return 999.0, round(preds1_percentage,3), round(preds2_percentage,3)
 	if preds2 == 0: return 0.0, round(preds1_percentage,3), round(preds2_percentage,3)
 	return round(preds2_percentage/preds1_percentage,3), round(preds1_percentage,3), round(preds2_percentage,3)
 
@@ -147,15 +147,15 @@ def performTargetPrediction(models):
 		percent = (float(i)/float(len(models)))*100 + 1
 		sys.stdout.write(' Performing Classification on Query Molecules: %3d%%\r' % percent)
 		sys.stdout.flush()
-		if result is not None: 
+		if result is not None:
 			prediction_results.append(result)
 			updateHits(disease_links,disease_hits,result[1],result[2],result[4])
 			updateHits(pathway_links,pathway_hits,result[1],result[2],result[4])
 	pool.close()
 	pool.join()
 	return prediction_results
-	
-#update counts for each pathway/disease that is hit by predictions	
+
+#update counts for each pathway/disease that is hit by predictions
 def updateHits(links,hits,uniprot,hit1,hit2):
 	try:
 		for idx in links[uniprot]:
@@ -169,7 +169,7 @@ def updateHits(links,hits,uniprot,hit1,hit2):
 				hits[idx] = np.array([hit1,hit2])
 	except KeyError: return
 	return
-	
+
 #worker for the processHits to calculate the prediction ratio, Chi-square test in parallel
 def doHitProcess(inp):
 	idx, hits, n_f1_hits, n_f2_hits = inp

--- a/predict_enriched_two_libraries.py
+++ b/predict_enriched_two_libraries.py
@@ -48,6 +48,9 @@ def arrayFP(inp):
 #import user query
 def importQuery(in_file):
 	query = open(in_file).read().splitlines()
+	#collect IDs, if present
+	if len(query[0].split()) > 1:
+		query = [line.split()[0] for line in query]
 	matrix = np.empty((len(query), 2048), dtype=np.uint8)
 	smiles_per_core = int(math.ceil(len(query) / N_cores)+1)
 	chunked_smiles = [query[x:x+smiles_per_core] for x in xrange(0, len(query), smiles_per_core)]

--- a/predict_enriched_two_libraries_decision_tree.py
+++ b/predict_enriched_two_libraries_decision_tree.py
@@ -51,7 +51,7 @@ def arrayFP(inp):
 #import user query
 def importQuery(in_file):
 	query = open(in_file).read().splitlines()
-	#collect IDs, if present
+	#discard IDs, if present
 	if len(query[0].split()) > 1:
 		query = [line.split()[0] for line in query]
 	matrix = np.empty((len(query), 2048), dtype=np.uint8)

--- a/predict_per_comp.py
+++ b/predict_per_comp.py
@@ -32,7 +32,7 @@ def calcFingerprints(smiles):
 	m1 = Chem.MolFromSmiles(smiles)
 	fp = AllChem.GetMorganFingerprintAsBitVect(m1,2, nBits=2048)
 	binary = fp.ToBitString()
-	return list(binary) 
+	return list(binary)
 
 #calculate fingerprints for chunked array of smiles
 def arrayFP(inp):
@@ -68,8 +68,15 @@ def importQuery(in_file):
 		processed_smi += result[1]
 	pool.close()
 	pool.join()
-	#if IDs aren't present, use SMILES as IDs
-	if not ids:
+	#remove IDs of SMILES parsing errors
+	if ids:
+		processed_ids = []
+		for idx, smi in enumerate(query):
+			if smi in processed_smi:
+				processed_ids.append(ids[idx])
+		ids = processed_ids
+	#if IDs weren't present, use SMILES as IDs
+	else:
 		ids = processed_smi
 	return matrix[:current_end], processed_smi, ids
 
@@ -111,7 +118,7 @@ def getPathwayInfo():
 		except KeyError:
 			return_dict1[l[0]] = [l[1]]
 		return_dict2[l[1]] = l[2:]
-	return return_dict1, return_dict2 
+	return return_dict1, return_dict2
 
 #unzip a pkl model
 def open_Model(mod):
@@ -122,7 +129,7 @@ def open_Model(mod):
 			clf = cPickle.load(fid)
 	return clf
 
-#prediction worker	
+#prediction worker
 def doTargetPrediction(pickled_model_name):
 	if os.name == 'nt': sep = '\\'
 	else: sep = '/'
@@ -155,7 +162,7 @@ def performTargetPrediction(models):
 	pool.join()
 	prediction_matrix = np.array([j for i,j in sorted(prediction_results.items())]).transpose()
 	return prediction_results, prediction_matrix, sorted(list(total_pw)), sorted(list(total_disease))
-	
+
 #initializer for the pool
 def initPool(querymatrix_, threshold_):
 	global querymatrix, threshold

--- a/predict_raw.py
+++ b/predict_raw.py
@@ -25,13 +25,13 @@ def introMessage():
 	print '==============================================================================================\n'
 	return
 
-	
+
 #calculate 2048bit morgan fingerprints, radius 2
 def calcFingerprints(smiles):
 	m1 = Chem.MolFromSmiles(smiles)
 	fp = AllChem.GetMorganFingerprintAsBitVect(m1,2, nBits=2048)
 	binary = fp.ToBitString()
-	return list(binary) 
+	return list(binary)
 
 #calculate fingerprints for chunked array of smiles
 def arrayFP(inp):
@@ -67,8 +67,15 @@ def importQuery(in_file):
 		processed_smi += result[1]
 	pool.close()
 	pool.join()
-	#if IDs aren't present, use SMILES as IDs
-	if not ids:
+	#remove IDs of SMILES parsing errors
+	if ids:
+		processed_ids = []
+		for idx, smi in enumerate(query):
+			if smi in processed_smi:
+				processed_ids.append(ids[idx])
+		ids = processed_ids
+	#if IDs weren't present, use SMILES as IDs
+	else:
 		ids = processed_smi
 	return matrix[:current_end], processed_smi, ids
 
@@ -89,7 +96,7 @@ def open_Model(mod):
 			clf = cPickle.load(fid)
 	return clf
 
-#prediction worker	
+#prediction worker
 def doTargetPrediction(pickled_model_name):
 	if os.name == 'nt': sep = '\\'
 	else: sep = '/'
@@ -113,7 +120,7 @@ def performTargetPrediction(models):
 	pool.close()
 	pool.join()
 	return prediction_results
-	
+
 #initializer for the pool
 def initPool(querymatrix_):
 	global querymatrix

--- a/predict_raw.py
+++ b/predict_raw.py
@@ -48,6 +48,12 @@ def arrayFP(inp):
 #import user query
 def importQuery(in_file):
 	query = open(in_file).read().splitlines()
+	#collect IDs, if present
+	if len(query[0].split()) > 1:
+		ids = [line.split()[1] for line in query]
+		query = [line.split()[0] for line in query]
+	else:
+		ids = None
 	matrix = np.empty((len(query), 2048), dtype=np.uint8)
 	smiles_per_core = int(math.ceil(len(query) / N_cores)+1)
 	chunked_smiles = [query[x:x+smiles_per_core] for x in xrange(0, len(query), smiles_per_core)]
@@ -61,7 +67,10 @@ def importQuery(in_file):
 		processed_smi += result[1]
 	pool.close()
 	pool.join()
-	return matrix[:current_end], processed_smi
+	#if IDs aren't present, use SMILES as IDs
+	if not ids:
+		ids = processed_smi
+	return matrix[:current_end], processed_smi, ids
 
 #get info for uniprots
 def getUniprotInfo():
@@ -120,16 +129,26 @@ if __name__ == '__main__':
 	introMessage()
 	print ' Predicting Targets for ' + input_name
 	print ' Using ' + str(N_cores) + ' Cores'
+	try:
+		desired_organism = sys.argv[3]
+	except IndexError:
+		desired_organism = None
 	models = [modelfile for modelfile in glob.glob(os.path.dirname(os.path.abspath(__file__)) + sep + 'models' + sep + '*.zip')]
 	model_info = getUniprotInfo()
+	if desired_organism is not None:
+		models = [mod for mod in models if model_info[mod.split(sep)[-1].split('.')[0]][4] == desired_organism]
+		print ' Predicting for organism : ' + desired_organism
+		out_name = input_name + '_out_raw_' + desired_organism[:3] + '.txt'
+		out_file = open(out_name, 'w')
+	else:
+		out_name = input_name + '_out_raw.txt'
+		out_file = open(out_name, 'w')
 	print ' Total Number of Classes : ' + str(len(models))
-	output_name = input_name + '_out_raw.txt'
-	out_file = open(output_name, 'w')
-	querymatrix,smiles = importQuery(input_name)
+	querymatrix,smiles,ids = importQuery(input_name)
 	print ' Total Number of Query Molecules : ' + str(len(querymatrix))
 	prediction_results = performTargetPrediction(models)
-	out_file.write('Uniprot\tPref_Name\tGene ID\tTarget_Class\tOrganism\tPDB_ID\tDisGeNET_Diseases_0.06\tChEMBL_First_Published\t' + '\t'.join(map(str,smiles)) + '\n')
+	out_file.write('Uniprot\tPref_Name\tGene ID\tTarget_Class\tOrganism\tPDB_ID\tDisGeNET_Diseases_0.06\tChEMBL_First_Published\t' + '\t'.join(map(str,ids)) + '\n')
 	for row in sorted(prediction_results):
 		out_file.write('\t'.join(map(str,model_info[row[0]])) + '\t' + '\t'.join(map(str,row[1])) + '\n')
-	print '\n Wrote Results to: ' + output_name
+	print '\n Wrote Results to: ' + out_name
 	out_file.close()

--- a/predict_target_fingerprints.py
+++ b/predict_target_fingerprints.py
@@ -68,8 +68,15 @@ def importQuery(in_file):
 		processed_smi += result[1]
 	pool.close()
 	pool.join()
-	#if IDs aren't present, use SMILES as IDs
-	if not ids:
+	#remove IDs of SMILES parsing errors
+	if ids:
+		processed_ids = []
+		for idx, smi in enumerate(query):
+			if smi in processed_smi:
+				processed_ids.append(ids[idx])
+		ids = processed_ids
+	#if IDs weren't present, use SMILES as IDs
+	else:
 		ids = processed_smi
 	return matrix[:current_end], processed_smi, ids
 

--- a/predict_target_fingerprints.py
+++ b/predict_target_fingerprints.py
@@ -32,7 +32,7 @@ def calcFingerprints(smiles):
 	m1 = Chem.MolFromSmiles(smiles)
 	fp = AllChem.GetMorganFingerprintAsBitVect(m1,2, nBits=2048)
 	binary = fp.ToBitString()
-	return list(binary) 
+	return list(binary)
 
 #calculate fingerprints for chunked array of smiles
 def arrayFP(inp):
@@ -49,6 +49,12 @@ def arrayFP(inp):
 #import user query
 def importQuery(in_file):
 	query = open(in_file).read().splitlines()
+	#collect IDs, if present
+	if len(query[0].split()) > 1:
+		ids = [line.split()[1] for line in query]
+		query = [line.split()[0] for line in query]
+	else:
+		ids = None
 	matrix = np.empty((len(query), 2048), dtype=np.uint8)
 	smiles_per_core = int(math.ceil(len(query) / N_cores)+1)
 	chunked_smiles = [query[x:x+smiles_per_core] for x in xrange(0, len(query), smiles_per_core)]
@@ -62,7 +68,10 @@ def importQuery(in_file):
 		processed_smi += result[1]
 	pool.close()
 	pool.join()
-	return matrix[:current_end], processed_smi
+	#if IDs aren't present, use SMILES as IDs
+	if not ids:
+		ids = processed_smi
+	return matrix[:current_end], processed_smi, ids
 
 #get info for uniprots
 def getUniprotInfo():
@@ -71,7 +80,7 @@ def getUniprotInfo():
 	model_info = [l.split('\t') for l in open(os.path.dirname(os.path.abspath(__file__)) + sep + 'classes_in_model.txt').read().splitlines()]
 	return_dict = {l[0] : l[0:7] for l in model_info}
 	return return_dict
-	
+
 #unzip a pkl model
 def open_Model(mod):
 	if os.name == 'nt': sep = '\\'
@@ -81,7 +90,7 @@ def open_Model(mod):
 			clf = cPickle.load(fid)
 	return clf
 
-#prediction worker	
+#prediction worker
 def doTargetPrediction(pickled_model_name):
 	if os.name == 'nt': sep = '\\'
 	else: sep = '/'
@@ -140,14 +149,14 @@ if __name__ == '__main__':
 		out_name = input_name + '_out_target_fingerprints_' + str(threshold) + '.txt'
 		out_file = open(out_name, 'w')
 	print ' Total Number of Classes : ' + str(len(models))
-	#perform target predictions and tp fingerprints to file 
-	querymatrix,smiles = importQuery(input_name)
+	#perform target predictions and tp fingerprints to file
+	querymatrix,smiles,ids = importQuery(input_name)
 	print ' Total Number of Query Molecules : ' + str(len(querymatrix))
 	print ' Using threshold : ' + str(threshold)
 	sorted_targets,prediction_matrix = performTargetPrediction(models)
 	out_file.write('Compound\t' + '\t'.join(map(str,[i for i in sorted_targets])) + '\n')
 	for i, row in enumerate(prediction_matrix):
 		#write target prediction fp
-		out_file.write(smiles[i] + '\t' + '\t'.join(map(str,row)) + '\n')
+		out_file.write(ids[i] + '\t' + '\t'.join(map(str,row)) + '\n')
 	print '\n Wrote Results to: ' + out_name
 	out_file.close()

--- a/predict_target_fingerprints.py
+++ b/predict_target_fingerprints.py
@@ -32,7 +32,7 @@ def calcFingerprints(smiles):
 	m1 = Chem.MolFromSmiles(smiles)
 	fp = AllChem.GetMorganFingerprintAsBitVect(m1,2, nBits=2048)
 	binary = fp.ToBitString()
-	return list(binary) 
+	return list(binary)
 
 #calculate fingerprints for chunked array of smiles
 def arrayFP(inp):
@@ -49,6 +49,11 @@ def arrayFP(inp):
 #import user query
 def importQuery(in_file):
 	query = open(in_file).read().splitlines()
+	if len(query[0].split()) > 1:
+		ids = [line.split()[1] for line in query]
+		query = [line.split()[0] for line in query]
+	else:
+		ids = None
 	matrix = np.empty((len(query), 2048), dtype=np.uint8)
 	smiles_per_core = int(math.ceil(len(query) / N_cores)+1)
 	chunked_smiles = [query[x:x+smiles_per_core] for x in xrange(0, len(query), smiles_per_core)]
@@ -62,7 +67,9 @@ def importQuery(in_file):
 		processed_smi += result[1]
 	pool.close()
 	pool.join()
-	return matrix[:current_end], processed_smi
+	if not ids:
+		ids = processed_smi
+	return matrix[:current_end], processed_smi, ids
 
 #get info for uniprots
 def getUniprotInfo():
@@ -71,7 +78,7 @@ def getUniprotInfo():
 	model_info = [l.split('\t') for l in open(os.path.dirname(os.path.abspath(__file__)) + sep + 'classes_in_model.txt').read().splitlines()]
 	return_dict = {l[0] : l[0:7] for l in model_info}
 	return return_dict
-	
+
 #unzip a pkl model
 def open_Model(mod):
 	if os.name == 'nt': sep = '\\'
@@ -81,7 +88,7 @@ def open_Model(mod):
 			clf = cPickle.load(fid)
 	return clf
 
-#prediction worker	
+#prediction worker
 def doTargetPrediction(pickled_model_name):
 	if os.name == 'nt': sep = '\\'
 	else: sep = '/'
@@ -140,14 +147,14 @@ if __name__ == '__main__':
 		out_name = input_name + '_out_target_fingerprints_' + str(threshold) + '.txt'
 		out_file = open(out_name, 'w')
 	print ' Total Number of Classes : ' + str(len(models))
-	#perform target predictions and tp fingerprints to file 
-	querymatrix,smiles = importQuery(input_name)
+	#perform target predictions and tp fingerprints to file
+	querymatrix,smiles,ids = importQuery(input_name)
 	print ' Total Number of Query Molecules : ' + str(len(querymatrix))
 	print ' Using threshold : ' + str(threshold)
 	sorted_targets,prediction_matrix = performTargetPrediction(models)
 	out_file.write('Compound\t' + '\t'.join(map(str,[i for i in sorted_targets])) + '\n')
 	for i, row in enumerate(prediction_matrix):
 		#write target prediction fp
-		out_file.write(smiles[i] + '\t' + '\t'.join(map(str,row)) + '\n')
+		out_file.write(ids[i] + '\t' + '\t'.join(map(str,row)) + '\n')
 	print '\n Wrote Results to: ' + out_name
 	out_file.close()

--- a/predict_target_fingerprints.py
+++ b/predict_target_fingerprints.py
@@ -120,8 +120,8 @@ if __name__ == '__main__':
 	input_name, N_cores,  = sys.argv[1], int(sys.argv[2])
 	try:
 		threshold = float(sys.argv[3])
-	except KeyError:
-		if sys.argv[3] == 'None': threshold = 'None'
+	except ValueError:
+		if sys.argv[3] == 'None': threshold = None
 		else: print 'Enter valid threshold or "None"'
 	introMessage()
 	print ' Using ' + str(N_cores) + ' Cores'

--- a/sim_to_train.py
+++ b/sim_to_train.py
@@ -66,8 +66,15 @@ def importQuery(in_file):
 		processed_smi += result[1]
 	pool.close()
 	pool.join()
-	#if IDs aren't present, use SMILES as IDs
-	if not ids:
+	#remove IDs of SMILES parsing errors
+	if ids:
+		processed_ids = []
+		for idx, smi in enumerate(query):
+			if smi in processed_smi:
+				processed_ids.append(ids[idx])
+		ids = processed_ids
+	#if IDs weren't present, use SMILES as IDs
+	else:
 		ids = processed_smi
 	return processed_fp, processed_smi, ids
 


### PR DESCRIPTION
Bug in handling identifiers in .smi files: they weren't discarded for SMILE strings which couldn't be parsed. These edits fix the issue.